### PR TITLE
Dev -- Storing Room Data & Object Categories

### DIFF
--- a/Action.cs
+++ b/Action.cs
@@ -9,6 +9,8 @@ namespace cse210_final_metroidvania
     /// </summary>
     public abstract class Action
     {
-        public abstract void Execute(Dictionary<string, List<Actor>> cast);
+        protected string _newRoom = "";
+
+        public abstract string Execute(Dictionary<string, List<Actor>> cast);
     }
 }

--- a/Casting/Actor.cs
+++ b/Casting/Actor.cs
@@ -12,6 +12,7 @@ namespace cse210_final_metroidvania.Casting
         protected bool _hasGravity;
         protected bool _canJump;
         protected bool _onGround;
+        protected bool _canBounceOffEnv;
 
         protected int _width = 0;
         protected int _height = 0;
@@ -79,6 +80,16 @@ namespace cse210_final_metroidvania.Casting
         public bool IsOnGround()
         {
             return _onGround;
+        }
+
+        public void SetCanBounceOffEnv(bool canBounceOffEnv)
+        {
+            _canBounceOffEnv = canBounceOffEnv;
+        }
+
+        public bool CanBounceOffEnv()
+        {
+            return _canBounceOffEnv;
         }
 
         public string GetText()

--- a/Casting/Enemies/BasicEnemy.cs
+++ b/Casting/Enemies/BasicEnemy.cs
@@ -1,0 +1,46 @@
+using System;
+using cse210_final_metroidvania.Services;
+
+namespace cse210_final_metroidvania.Casting.Enemies
+{
+    /// <summary>
+    /// Base class for all actors in the game.
+    /// </summary>
+    public class BasicEnemy : Enemy
+    {
+        private const int BASIC_ATTACK_DAMAGE = 10;
+        private const int BASIC_ATTACK_STUN_TIME = 20;
+
+        public BasicEnemy()
+        {
+            SetHeight(Constants.ENEMY_HEIGHT);
+            SetWidth(Constants.ENEMY_WIDTH);
+            // SetImage(Constants.IMAGE_HERO);
+            SetPosition(new Point(700, 500 - Constants.ENEMY_HEIGHT));
+            SetVelocity(new Point(Constants.ENEMY_SPEED, Constants.GRAVITY));
+            SetCanBounceOffEnv(true);
+        }
+
+        public override void RightAttack(Hero hero, PhysicsService physicsService)
+        {
+            physicsService.ChangeAcceleration(hero, Constants.BASIC_ENEMY_HIT_KNOCKBACK, "x");
+            physicsService.ChangeAcceleration(hero, -Constants.BASIC_ENEMY_HIT_KNOCKBACK, "y");
+
+            hero.SetHitState(true);
+            hero.SetStunTime(BASIC_ATTACK_STUN_TIME);
+            hero.LoseHealth(BASIC_ATTACK_DAMAGE);
+        }
+
+        public override void LeftAttack(Hero hero, PhysicsService physicsService)
+        {
+            physicsService.ChangeAcceleration(hero, -Constants.BASIC_ENEMY_HIT_KNOCKBACK, "xy");
+
+            hero.SetHitState(true);
+            hero.SetStunTime(BASIC_ATTACK_STUN_TIME);
+            hero.LoseHealth(BASIC_ATTACK_DAMAGE);
+        }
+
+
+    }
+
+}

--- a/Casting/Enemy.cs
+++ b/Casting/Enemy.cs
@@ -13,14 +13,14 @@ namespace cse210_final_metroidvania.Casting
 
         public Enemy()
         {
-            SetHeight(Constants.ENEMY_HEIGHT);
-            SetWidth(Constants.ENEMY_WIDTH);
-            // SetImage(Constants.IMAGE_HERO);
-            SetPosition(new Point(700, 500 - Constants.ENEMY_HEIGHT));
-            SetVelocity(new Point(Constants.ENEMY_SPEED, Constants.GRAVITY));
+            // SetHeight(Constants.ENEMY_HEIGHT);
+            // SetWidth(Constants.ENEMY_WIDTH);
+            // // SetImage(Constants.IMAGE_ENEMY);
+            // SetPosition(new Point(700, 500 - Constants.ENEMY_HEIGHT));
+            // SetVelocity(new Point(Constants.ENEMY_SPEED, Constants.GRAVITY));
         }
 
-        public void BasicRightAttack(Hero hero, PhysicsService physicsService)
+        public virtual void RightAttack(Hero hero, PhysicsService physicsService)
         {
             physicsService.ChangeAcceleration(hero, Constants.BASIC_ENEMY_HIT_KNOCKBACK, "x");
             physicsService.ChangeAcceleration(hero, -Constants.BASIC_ENEMY_HIT_KNOCKBACK, "y");
@@ -30,7 +30,7 @@ namespace cse210_final_metroidvania.Casting
             hero.LoseHealth(BASIC_ATTACK_DAMAGE);
         }
 
-        public void BasicLeftAttack(Hero hero, PhysicsService physicsService)
+        public virtual void LeftAttack(Hero hero, PhysicsService physicsService)
         {
             physicsService.ChangeAcceleration(hero, -Constants.BASIC_ENEMY_HIT_KNOCKBACK, "xy");
 

--- a/Casting/EnvElement.cs
+++ b/Casting/EnvElement.cs
@@ -1,0 +1,32 @@
+using System;
+
+namespace cse210_final_metroidvania.Casting
+{
+    /// <summary>
+    /// Base class for all actors in the game.
+    /// </summary>
+    public class EnvElement : Actor
+    {
+        private double _frictionConstant;
+
+        public EnvElement()
+        {
+            SetHeight(Constants.ENV_ELEMENT_HEIGHT);
+            SetWidth(Constants.ENV_ELEMENT_WIDTH);
+            // SetImage(Constants.IMAGE_FLOOR);
+            SetFrictionConstant(0.5);
+            SetGravity(false);
+        }
+
+        public void SetFrictionConstant(double frictionConstant)
+        {
+            _frictionConstant = frictionConstant;
+        }
+
+        public double GetFrictionConstant()
+        {
+            return _frictionConstant;
+        }
+    }
+
+}

--- a/Casting/EnvironmentElements/Brick.cs
+++ b/Casting/EnvironmentElements/Brick.cs
@@ -1,0 +1,23 @@
+using System;
+using cse210_final_metroidvania.Casting;
+
+namespace cse210_final_metroidvania.Casting.EnvironmentElements
+{
+    /// <summary>
+    /// Base class for all actors in the game.
+    /// </summary>
+    public class Brick : EnvElement
+    {
+
+        public Brick()
+        {
+            SetHeight(Constants.ENV_ELEMENT_HEIGHT);
+            SetWidth(Constants.ENV_ELEMENT_WIDTH);
+            // SetImage(Constants.IMAGE_FLOOR);
+            SetFrictionConstant(0.5);
+            SetGravity(false);
+        }
+
+    }
+
+}

--- a/Casting/EnvironmentElements/Door.cs
+++ b/Casting/EnvironmentElements/Door.cs
@@ -1,0 +1,44 @@
+using System;
+using cse210_final_metroidvania.Casting;
+
+namespace cse210_final_metroidvania.Casting.EnvironmentElements
+{
+    /// <summary>
+    /// Base class for all actors in the game.
+    /// </summary>
+    public class Door : EnvElement
+    {
+        private string _newRoomName;
+        private Point _newHeroPosition;
+
+        public Door()
+        {
+            SetHeight(Constants.ENV_ELEMENT_HEIGHT);
+            SetWidth(5);
+            // SetImage(Constants.IMAGE_FLOOR);
+            SetGravity(false);
+        }
+
+        public string GetNewRoomName()
+        {
+            return _newRoomName;
+        }
+
+        public void SetNewRoomName(string newRoomName)
+        {
+            _newRoomName = newRoomName;
+        }
+
+        public Point GetNewHeroPosition()
+        {
+            return _newHeroPosition;
+        }
+
+        public void SetNewHeroPosition(Point newHeroPosition)
+        {
+            _newHeroPosition = newHeroPosition;
+        }
+
+    }
+
+}

--- a/Casting/Hero.cs
+++ b/Casting/Hero.cs
@@ -10,6 +10,8 @@ namespace cse210_final_metroidvania.Casting
         private bool _isHit = false;
         private int _health;
         private int _stunTime = 0;
+        private string _equippedWeapon;
+        private double _acceleration;
 
         public Hero()
         {
@@ -19,7 +21,10 @@ namespace cse210_final_metroidvania.Casting
             SetHealth(100);
             SetPosition(new Point(100, 100));
             SetVelocity(new Point(0, 0));
+            SetAcceleration(1.0);
             SetGravity(true);
+            SetCanBounceOffEnv(false);
+            SetEquippedWeapon("Nothing");
         }
 
         public int GetHealth()
@@ -65,6 +70,26 @@ namespace cse210_final_metroidvania.Casting
         public void SetStunTime(int stunTime)
         {
             _stunTime = stunTime;
+        }
+
+        public string GetEquippedWeapon()
+        {
+            return _equippedWeapon;
+        }
+
+        public void SetEquippedWeapon(string equippedWeapon)
+        {
+            _equippedWeapon = equippedWeapon;
+        }
+
+        public double GetAcceleration()
+        {
+            return _acceleration;
+        }
+
+        public void SetAcceleration(double acceleration)
+        {
+            _acceleration = acceleration;
         }
     }
 

--- a/Casting/HudElements/EquippedWeapon.cs
+++ b/Casting/HudElements/EquippedWeapon.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using cse210_final_metroidvania.Casting.HudElements;
+
+namespace cse210_final_metroidvania.Casting.HudElements
+{
+    /// <summary>
+    /// Will display the hero's currently set equipped weapon
+    /// </summary>
+    public class EquippedWeapon : HUD
+    {
+
+        public EquippedWeapon()
+        {
+            SetText(_text);
+            SetPosition(new Point(1000,20));
+        }
+
+        public override void Update(Hero hero)
+        {
+            _text = $"Weapon: {hero.GetEquippedWeapon()}";
+        }
+
+    }
+
+}

--- a/Casting/HudElements/HUD.cs
+++ b/Casting/HudElements/HUD.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using cse210_final_metroidvania.Casting.HudElements;
+
+
+namespace cse210_final_metroidvania.Casting.HudElements
+{
+    /// <summary>
+    /// Base class for all HUD elements.
+    /// </summary>
+    public abstract class HUD : Actor
+    {
+        public abstract void Update(Hero hero);
+    }
+
+}

--- a/Casting/HudElements/Health.cs
+++ b/Casting/HudElements/Health.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using cse210_final_metroidvania.Casting.HudElements;
+
+namespace cse210_final_metroidvania.Casting.HudElements
+{
+    /// <summary>
+    /// Will display the hero's current health.
+    /// </summary>
+    public class Health : HUD
+    {
+        // private int _health;
+
+
+        public Health()
+        {
+            SetText(_text);
+            SetPosition(new Point(20,20));
+        }
+
+        public override void Update(Hero hero)
+        {
+            _text = $"Health: {hero.GetHealth()}";
+        }
+
+
+    }
+
+}

--- a/Casting/HudElements/Velocity.cs
+++ b/Casting/HudElements/Velocity.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using cse210_final_metroidvania.Casting.HudElements;
+
+namespace cse210_final_metroidvania.Casting.HudElements
+{
+    /// <summary>
+    /// Will display the hero's current velocity.
+    /// </summary>
+    public class Velocity : HUD
+    {
+        // private int _health;
+
+
+        public Velocity()
+        {
+            SetText(_text);
+            SetPosition(new Point(20,50));
+        }
+
+        public override void Update(Hero hero)
+        {
+            _text = $"Velocity: {hero.GetVelocity().GetX():0,0.00}";
+        }
+
+
+    }
+
+}

--- a/Constants.cs
+++ b/Constants.cs
@@ -22,8 +22,8 @@ namespace cse210_final_metroidvania
         public const string SOUND_BOUNCE = "./Assets/boing.wav";
         public const string SOUND_OVER = "./Assets/over.wav";
 
-        public const int FLOOR_WIDTH = 50;
-        public const int FLOOR_HEIGHT = 50;
+        public const int ENV_ELEMENT_WIDTH = 25;
+        public const int ENV_ELEMENT_HEIGHT = 25;
 
         public const int HERO_WIDTH = 24;
         public const int HERO_HEIGHT = 24;

--- a/Director.cs
+++ b/Director.cs
@@ -16,14 +16,19 @@ namespace cse210_final_metroidvania
     public class Director
     {
         private AudioService _audioService = new AudioService();
+        private CastPrepService _castPrepService = new CastPrepService();
         private bool _keepPlaying = true;
+        private Dictionary<string, Dictionary<string, List<Actor>>> _map;
         private Dictionary<string, List<Actor>> _cast;
         private Dictionary<string, List<Action>> _script;
 
-        public Director(Dictionary<string, List<Actor>> cast, Dictionary<string, List<Action>> script)
+        // public Director(Dictionary<string, List<Actor>> cast, Dictionary<string, List<Action>> script)
+        public Director(Dictionary<string, Dictionary<string, List<Actor>>> map, Dictionary<string, List<Action>> script)
         {
-            _cast = cast;
+            _map = map;
             _script = script;
+            _cast = _castPrepService.PopulateCast(map, "room0");
+            // ((Hero)map["room0"]["heros"][0]));
         }
 
         /// <summary>
@@ -58,7 +63,22 @@ namespace cse210_final_metroidvania
 
             foreach (Action action in actions)
             {
-                action.Execute(_cast);
+                string newRoom = action.Execute(_cast);
+                
+
+                if (newRoom != "")
+                {
+                    Console.WriteLine(newRoom);
+                    Actor hero = _cast["heros"][0];
+                    _cast["heros"].RemoveAt(0);
+
+                    _cast = _castPrepService.PopulateCast(_map, newRoom);
+
+                    // hero.SetPosition(new Point(100,100));
+
+                    _cast["heros"].Add(((Hero)hero));
+                }
+                
             }
         }
 

--- a/MapInitializer.cs
+++ b/MapInitializer.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using cse210_final_metroidvania.Casting;
+using cse210_final_metroidvania.Casting.EnvironmentElements;
+using cse210_final_metroidvania.Casting.Enemies;
+using cse210_final_metroidvania.Casting.HudElements;
+
+namespace cse210_final_metroidvania
+{
+    public class MapInitializer
+    {
+        Dictionary<string, Dictionary<string, List<Actor>>> _rooms = new Dictionary<string, Dictionary<string, List<Actor>>>();
+
+
+        public MapInitializer()
+        {
+            InitializeCast0();
+            InitializeCast1();
+        }
+
+        public Dictionary<string, Dictionary<string, List<Actor>>> GetGameMap()
+        {
+            return _rooms;
+        }
+
+        private void InitializeCast0()
+        {
+            Dictionary<string, List<Actor>> cast0 = new Dictionary<string, List<Actor>>();
+
+            ///////////////////////////////////////////
+            // Enviroment Elements
+            ///////////////////////////////////////////
+            cast0["envElements"] = new List<Actor>();
+
+            Brick floor = new Brick();
+            floor.SetPosition(new Point(0, 500));
+            floor.SetWidth(800);
+            // _rooms["room0"].Add("envElements", floor);
+            cast0["envElements"].Add(floor);
+
+            // For Collision debug
+            EnvElement barrier = new EnvElement();
+            barrier.SetPosition(new Point(350, 450));
+            cast0["envElements"].Add(barrier);
+
+            EnvElement barrier2 = new EnvElement();
+            barrier2.SetPosition(new Point(750, 450));
+            cast0["envElements"].Add(barrier2);
+            //
+
+            Door door = new Door();
+            door.SetNewRoomName("room1");
+            door.SetNewHeroPosition(new Point(200, 200));
+            door.SetPosition(new Point(10, 450));
+            cast0["envElements"].Add(door);
+
+            ///////////////////////////////////////////
+            // Hero
+            ///////////////////////////////////////////
+            cast0["heros"] = new List<Actor>();
+
+            Hero hero = new Hero();
+            cast0["heros"].Add(hero);
+
+            ///////////////////////////////////////////
+            // Enemies
+            ///////////////////////////////////////////
+            cast0["enemies"] = new List<Actor>();
+
+            BasicEnemy zombie = new BasicEnemy();
+            cast0["enemies"].Add(zombie);
+
+            ///////////////////////////////////////////
+            // HUD
+            ///////////////////////////////////////////
+            cast0["hud"] = new List<Actor>();
+
+            Health health = new Health();
+            cast0["hud"].Add(health);
+
+            Velocity velocity = new Velocity();
+            cast0["hud"].Add(velocity);
+
+            EquippedWeapon equippedWeapon = new EquippedWeapon();
+            cast0["hud"].Add(equippedWeapon);
+
+            ///////////////////////////////////////////
+            _rooms["room0"] = cast0;
+        }
+
+        private void InitializeCast1()
+        {
+            Dictionary<string, List<Actor>> cast1 = new Dictionary<string, List<Actor>>();
+
+            ///////////////////////////////////////////
+            // Enviroment Elements
+            ///////////////////////////////////////////
+            cast1["envElements"] = new List<Actor>();
+
+            Brick floor = new Brick();
+            floor.SetPosition(new Point(0, 500));
+            floor.SetWidth(800);
+            // _rooms["room0"].Add("envElements", floor);
+            cast1["envElements"].Add(floor);
+
+            // // For Collision debug
+            // EnvElement barrier = new EnvElement();
+            // barrier.SetPosition(new Point(350, 450));
+            // cast1["envElements"].Add(barrier);
+
+            // EnvElement barrier2 = new EnvElement();
+            // barrier2.SetPosition(new Point(750, 450));
+            // cast1["envElements"].Add(barrier2);
+            // //
+
+            ///////////////////////////////////////////
+            // Hero
+            ///////////////////////////////////////////
+            cast1["heros"] = new List<Actor>();
+
+            ///////////////////////////////////////////
+            // Enemies
+            ///////////////////////////////////////////
+            cast1["enemies"] = new List<Actor>();
+
+            // BasicEnemy zombie = new BasicEnemy();
+            // cast1["enemies"].Add(zombie);
+
+            ///////////////////////////////////////////
+            // HUD
+            ///////////////////////////////////////////
+            cast1["hud"] = new List<Actor>();
+
+            Health health = new Health();
+            cast1["hud"].Add(health);
+
+            Velocity velocity = new Velocity();
+            cast1["hud"].Add(velocity);
+
+            EquippedWeapon equippedWeapon = new EquippedWeapon();
+            cast1["hud"].Add(equippedWeapon);
+
+            ///////////////////////////////////////////
+            _rooms["room1"] = cast1;
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using cse210_final_metroidvania.Services;
 using cse210_final_metroidvania.Casting;
+using cse210_final_metroidvania.Casting.Enemies;
+using cse210_final_metroidvania.Casting.HudElements;
+using cse210_final_metroidvania.Casting.EnvironmentElements;
 using cse210_final_metroidvania.Scripting;
 using System.Collections.Generic;
 
@@ -10,48 +13,62 @@ namespace cse210_final_metroidvania
     {
         static void Main(string[] args)
         {
-            // The Cast
-            Dictionary<string, List<Actor>> cast = new Dictionary<string, List<Actor>>();
+            // // The Cast
+            // Dictionary<string, List<Actor>> cast = new Dictionary<string, List<Actor>>();
 
-            // The Floor
-            cast["floor"] = new List<Actor>();
+            // // The EnvElements
+            // cast["envElements"] = new List<Actor>();
 
-            int y = 500;
-            for (int x = 0; x < 850; x+=50)
-            {
-                Floor floor = new Floor();
-                floor.SetPosition(new Point(x, y));
-                cast["floor"].Add(floor);
-            }
+            // // int y = 500;
+            // // for (int x = 0; x < 850; x+=50)
+            // // {
+            // //     EnvElement floor = new EnvElement();
+            // //     floor.SetPosition(new Point(x, y));
+            // //     cast["envElements"].Add(floor);
+            // // }
+            // Brick floor = new Brick();
+            // floor.SetPosition(new Point(0, 500));
+            // floor.SetWidth(800);
+            // cast["envElements"].Add(floor);
             
-            // For Collision debug
-            Floor barrier = new Floor();
-            barrier.SetPosition(new Point(350, 450));
-            cast["floor"].Add(barrier);
+            // // For Collision debug
+            // EnvElement barrier = new EnvElement();
+            // barrier.SetPosition(new Point(350, 450));
+            // cast["envElements"].Add(barrier);
 
-            Floor barrier2 = new Floor();
-            barrier2.SetPosition(new Point(750, 450));
-            cast["floor"].Add(barrier2);
-            //
+            // EnvElement barrier2 = new EnvElement();
+            // barrier2.SetPosition(new Point(750, 450));
+            // cast["envElements"].Add(barrier2);
+            // //
 
-            // The Heros
-            cast["heros"] = new List<Actor>();
+            // // The Heros
+            // cast["heros"] = new List<Actor>();
 
-            Hero hero = new Hero();
-            cast["heros"].Add(hero);
+            // Hero hero = new Hero();
+            // cast["heros"].Add(hero);
 
-            // The Enemies
-            cast["enemies"] = new List<Actor>();
+            // // The Enemies
+            // cast["enemies"] = new List<Actor>();
 
-            Enemy zombie = new Enemy();
-            cast["enemies"].Add(zombie);
+            // BasicEnemy zombie = new BasicEnemy();
+            // cast["enemies"].Add(zombie);
 
+            // ///////////////////////////////////////////////////////
+            // // The HUD
+            // cast["hud"] = new List<Actor>();
 
-            cast["hud"] = new List<Actor>();
+            // Health health = new Health();
+            // cast["hud"].Add(health);
 
-            HUD hud = new HUD();
-            cast["hud"].Add(hud);
+            // Velocity velocity = new Velocity();
+            // cast["hud"].Add(velocity);
 
+            // EquippedWeapon equippedWeapon = new EquippedWeapon();
+            // cast["hud"].Add(equippedWeapon);
+            Dictionary<string, Dictionary<string, List<Actor>>> map = new Dictionary<string, Dictionary<string, List<Actor>>>();
+            
+            MapInitializer mapInitializer = new MapInitializer();
+            map = mapInitializer.GetGameMap();
 
             /////////////////////////////////////////////////////////////////////////////////
 
@@ -82,9 +99,6 @@ namespace cse210_final_metroidvania
             GravityAction gravityAction = new GravityAction(physicsService);
             script["update"].Add(gravityAction);
 
-            FrictionAction frictionAction = new FrictionAction(physicsService);
-            script["update"].Add(frictionAction);
-
             // Start up the game
             outputService.OpenWindow(Constants.MAX_X, Constants.MAX_Y, "Metroidvania", Constants.FRAME_RATE);
             audioService.StartAudio();
@@ -92,7 +106,7 @@ namespace cse210_final_metroidvania
 
             // Raylib.BeginMode2D(Camera2D camera); 
 
-            Director theDirector = new Director(cast, script);
+            Director theDirector = new Director(map, script);
             theDirector.Direct();
 
             audioService.StopAudio();

--- a/Scripting/ControlActorsAction.cs
+++ b/Scripting/ControlActorsAction.cs
@@ -20,7 +20,7 @@ namespace cse210_final_metroidvania.Scripting
             _physicsService = physicsService;
         }
 
-        public override void Execute(Dictionary<string, List<Actor>> cast)
+        public override string Execute(Dictionary<string, List<Actor>> cast)
         {
             Point direction = _inputService.GetDirection();
             List<Actor> heros = cast["heros"];
@@ -28,41 +28,62 @@ namespace cse210_final_metroidvania.Scripting
             // HERO CONTROLS
             foreach (Hero hero in heros)
             {
+                // This is in place to prevent player movement when an enemy attacks them. Each
+                // enemy will be able to provide it's own amount of stun time for it's unique
+                // attacks dynamically changing the wait time for movement to be unlocked. The
+                // hero's hit state is also set to false allow the hero to be effected by an
+                // enemy attack again. This is to prevent the potential for hit locking.
                 if (hero.GetStunTime() == 0)
                 {
                     hero.SetHitState(false);
                     Point velocity = hero.GetVelocity();
+                    double dx = velocity.GetX();
+                    double dy = velocity.GetY();
 
-                    if (hero.GetVelocity().GetX() > 0 && direction.GetX() == -1)
-                    {
-                        Console.WriteLine("Left Arrow");
-                        hero.SetVelocity(new Point(0, velocity.GetY()));
-                    }
-                    else if (hero.GetVelocity().GetX() < 0 && direction.GetX() == 1)
+                    // If right arrow was pressed
+                    if (direction.GetX() == 1)
                     {
                         Console.WriteLine("Right Arrow");
-                        hero.SetVelocity(new Point(0, velocity.GetY()));
+                        // Will make sure the hero only accelerates is they are below max speed and on ground.
+                        // Otherwise they will move max speed. This was done to put a cap on the max speed and
+                        // also so the player will be able to immediately change directions while in mid air.
+                        if (hero.GetVelocity().GetX() < Constants.HERO_SPEED -1 && hero.IsOnGround())
+                        {
+                            _physicsService.ChangeAcceleration(hero, hero.GetAcceleration(), "x");
+                        }
+                        else
+                        {
+                            hero.SetVelocity(new Point(Constants.HERO_SPEED, velocity.GetY()));
+                        }
                     }
-                    else if (direction.GetX() == 1)
-                    {
-                        Console.WriteLine("Right Arrow");
-                        hero.SetVelocity(new Point(Constants.HERO_SPEED, velocity.GetY()));
-                    }
+                    // If left arrow was pressed
                     else if (direction.GetX() == -1)
                     {
                         Console.WriteLine("Left Arrow");
-                        hero.SetVelocity(new Point(-Constants.HERO_SPEED, velocity.GetY()));
-                    }
-                    else
-                    {
-                        // Do something with friction here
-                        // hero.SetVelocity(new Point(0, velocity.GetY()));
+                        // Will make sure the hero only accelerates is they are below max speed and on ground.
+                        // Otherwise they will move max speed. This was done to put a cap on the max speed and
+                        // also so the player will be able to immediately change directions while in mid air.
+                        if (hero.GetVelocity().GetX() > -Constants.HERO_SPEED +1 && hero.IsOnGround())
+                        {
+                            _physicsService.ChangeAcceleration(hero, -hero.GetAcceleration(), "x");
+                        }
+                        else
+                        {
+                            hero.SetVelocity(new Point(-Constants.HERO_SPEED, velocity.GetY()));
+                        }
                     }
 
+                    // Will do a large amount of things when the hero jumps. A state that allows them to
+                    // jump will be flipped to false. This is to prevent the player from continuously
+                    // jumping while in the air. An onGround state will be set to false because they are
+                    // no longer on the ground. This mainly effects how movement works. See above for it's
+                    // use case. An gravity state is set to true. This adds a continuous negative acceleration
+                    // on the players vertical movement to allow an arching jump. The hero's base accleration 
+                    // is then set to the acceleration of the constant. I may move this to be inside the
+                    // hero.
                     if (direction.GetY() == 1 && hero.CanJump())
                     {
                         hero.SetCanJump(false);
-                        //  why does onground exist
                         hero.SetOnGround(false);
                         hero.SetGravity(true);
                         _physicsService.ChangeAcceleration(hero, Constants.HERO_JUMP_ACCELERATION, "y");
@@ -73,6 +94,8 @@ namespace cse210_final_metroidvania.Scripting
                     hero.CountDownStun();
                 }
             }
+
+            return _newRoom;
         }
     }
 }

--- a/Scripting/DrawActorsAction.cs
+++ b/Scripting/DrawActorsAction.cs
@@ -17,7 +17,7 @@ namespace cse210_final_metroidvania.Scripting
             _outputService = outputService;
         }
 
-        public override void Execute(Dictionary<string, List<Actor>> cast)
+        public override string Execute(Dictionary<string, List<Actor>> cast)
         {
             _outputService.StartDrawing();
 
@@ -27,6 +27,8 @@ namespace cse210_final_metroidvania.Scripting
             }
 
             _outputService.EndDrawing();
+
+            return _newRoom;
         }
 
     }

--- a/Scripting/GravityAction.cs
+++ b/Scripting/GravityAction.cs
@@ -13,10 +13,10 @@ namespace cse210_final_metroidvania
             _physicsService = physicsService;
         }
 
-        public override void Execute(Dictionary<string, List<Actor>> cast)
+        public override string Execute(Dictionary<string, List<Actor>> cast)
         {
             List<Actor> heros = cast["heros"];
-            List<Actor> floor = cast["floor"];
+            List<Actor> envElements = cast["envElements"];
 
 
             foreach (Actor hero in heros)
@@ -30,13 +30,15 @@ namespace cse210_final_metroidvania
                 }
             }
 
-            foreach (Actor floor_piece in floor)
+            foreach (Actor floor in envElements)
             {
-                if (floor_piece.HasGravity())
+                if (floor.HasGravity())
                 {
-                    _physicsService.ChangeAcceleration(floor_piece, Constants.GRAVITY, "y");
+                    _physicsService.ChangeAcceleration(floor, Constants.GRAVITY, "y");
                 }
             }
+
+            return _newRoom;
         }
     }
 }

--- a/Scripting/HandleCollisionsAction.cs
+++ b/Scripting/HandleCollisionsAction.cs
@@ -1,5 +1,8 @@
 using System.Collections.Generic;
 using cse210_final_metroidvania.Casting;
+using cse210_final_metroidvania.Casting.Enemies;
+using cse210_final_metroidvania.Casting.HudElements;
+using cse210_final_metroidvania.Casting.EnvironmentElements;
 using cse210_final_metroidvania.Services;
 using System;
 
@@ -19,25 +22,25 @@ namespace cse210_final_metroidvania
             _audioService = audioService;
         }
 
-        public override void Execute(Dictionary<string, List<Actor>> cast)
+        public override string Execute(Dictionary<string, List<Actor>> cast)
         {
             List<Actor> heros = cast["heros"];
-            List<Actor> floor = cast["floor"];
+            List<Actor> envElements = cast["envElements"];
             List<Actor> enemies = cast["enemies"];
-            List<Actor> huds = cast["hud"];
+            List<Actor> hud = cast["hud"];
             
             // HUD hud = new HUD();
             // hud = (HUD)hudActor;
 
             // This foreach loop is rediculous. I need the hud to act like a HUD not an Actor
-            foreach (HUD hud in huds)
+            foreach (HUD hud_element in hud)
             {
                 foreach (Hero hero in heros)
                 {
                     // loop through hero/floor collisions
-                    foreach (Floor floor_piece in floor)
+                    foreach (EnvElement floor in envElements)
                     {
-                        HandleStaticEnvironmentCollision(hero, floor_piece);
+                        HandleStaticEnvironmentCollision(hero, floor);
                     }
                     // loop through hero/enemy collisions
                     foreach (Enemy enemy in enemies)
@@ -45,18 +48,20 @@ namespace cse210_final_metroidvania
                         HandleDynamicEnemyCollision(hero, enemy);
 
                         // loop through enemy/floor collisions
-                        foreach (Actor floor_piece in floor)
+                        foreach (EnvElement floor_piece in envElements)
                         {
                             HandleStaticEnvironmentCollision(enemy, floor_piece);
                         }
                     }
 
-                    hud.UpdateHealth(hero);
+                    hud_element.Update(hero);
 
                 }
             }
 
             ActorsCleanUp(cast);
+
+            return _newRoom;
         }
 
         /// <summary>
@@ -65,7 +70,7 @@ namespace cse210_final_metroidvania
         /// The results of all comparisons will be relative to the second actor
         /// passed in.
         /// </summary>
-        private void HandleStaticEnvironmentCollision(Actor first, Actor second)
+        private void HandleStaticEnvironmentCollision(Actor first, EnvElement second)
         {
             if (_physicsService.IsCollision(first, second))
             {
@@ -78,27 +83,39 @@ namespace cse210_final_metroidvania
                         if (overlap.GetX() > 0)
                         {
                             // Collision left of second actor
-                            Console.WriteLine("left side collision");
                             _physicsService.HandleLeftCollision(first, second);
 
-                            // make this it's own function call
-                            if (first.GetType() == typeof(Enemy))
+                            if (first.CanBounceOffEnv())
                             {
-                                // Change this to internal function of Enemy
                                 first.SetVelocity(new Point(-Constants.ENEMY_SPEED, first.GetVelocity().GetY()));
+                            }
+
+                            // If the player hits the door it'll take them to a new room
+                            if (second.GetType() == typeof(Door))
+                            {
+                                Point newPosition = ((Door)second).GetNewHeroPosition();
+                                _newRoom = ((Door)second).GetNewRoomName();
+                                first.SetPosition(newPosition);
                             }
                         }
                         else
                         {
                             // Collision right of second actor
-                            Console.WriteLine("right side collision");
                             _physicsService.HandleRightCollision(first, second);
 
-                            // make this it's own function call
-                            if (first.GetType() == typeof(Enemy))
+                            if (first.CanBounceOffEnv())
                             {
-                                // Change this to internal functino of Enemy
                                 first.SetVelocity(new Point(Constants.ENEMY_SPEED, first.GetVelocity().GetY()));
+                            }
+
+
+                            // If the player hits the door it'll take them to a new room
+                            if (second.GetType() == typeof(Door))
+                            {
+                                Point newPosition = ((Door)second).GetNewHeroPosition();
+                                _newRoom = ((Door)second).GetNewRoomName();
+                                first.SetPosition(newPosition);
+
                             }
                         }
                     }
@@ -107,25 +124,18 @@ namespace cse210_final_metroidvania
                         if (overlap.GetY() > 0)
                         {
                             // Collision top of second actor
-                            // Console.WriteLine("top side collision");
                             _physicsService.HandleTopCollision(first, second);
-                            if (second.GetType() == typeof(Floor))
-                            {
-                                Floor floor = (Floor)second;
-                                _physicsService.HandleFriction(first, floor.GetFrictionConstant());
-                            }
+                            _physicsService.HandleFriction(first, second.GetFrictionConstant());
                             if (first.GetType() == typeof(Hero))
                             {
                                 first.SetCanJump(true);
-                                // find a way to get working
-                                // (Hero)first.SetHitState(false);
+                                ((Hero)first).SetHitState(false);
                             }
                             first.SetOnGround(true);
                         }
                         else
                         {
                             // Collision bottom of second actor
-                            Console.WriteLine("bottom side collision");
                             _physicsService.HandleBottomCollision(first, second);
                         }
                     }
@@ -139,11 +149,11 @@ namespace cse210_final_metroidvania
         /// The results of all comparisons will be relative to the second actor
         /// passed in.
         /// </summary>
-        private void HandleDynamicEnemyCollision(Actor first, Enemy second)
+        private void HandleDynamicEnemyCollision(Actor first, Enemy enemy)
         {
-            if (_physicsService.IsCollision(first, second))
+            if (_physicsService.IsCollision(first, enemy))
             {
-                Point overlap = _physicsService.GetCollisionOverlap(first, second);
+                Point overlap = _physicsService.GetCollisionOverlap(first, enemy);
 
                 if (overlap.GetX() != 0 && overlap.GetY() != 0)
                 {
@@ -155,11 +165,11 @@ namespace cse210_final_metroidvania
                             // Make the hero jump back unless the actor coming into
                             // contact is a sword. Then the enemy will jump back.
                             Console.WriteLine("left side collision");
-                            _physicsService.HandleLeftCollision(first, second);
+                            _physicsService.HandleLeftCollision(first, enemy);
 
                             if (first.GetType() == typeof(Hero))
                             {
-                                second.BasicLeftAttack((Hero)first, _physicsService);
+                                enemy.LeftAttack((Hero)first, _physicsService);
                             }
                         }
                         else
@@ -168,11 +178,11 @@ namespace cse210_final_metroidvania
                             // Make the hero jump back unless the actor coming into
                             // contact is a sword. Then the enemy will jump back.
                             Console.WriteLine("right side collision");
-                            _physicsService.HandleRightCollision(first, second);
+                            _physicsService.HandleRightCollision(first, enemy);
 
                             if (first.GetType() == typeof(Hero))
                             {
-                                second.BasicRightAttack((Hero)first, _physicsService);
+                                enemy.RightAttack((Hero)first, _physicsService);
                             }
                         }
                     }
@@ -182,11 +192,9 @@ namespace cse210_final_metroidvania
                         {
                             // Collision top of second actor
                             Console.WriteLine("top side collision");
-                            _physicsService.HandleTopCollision(first, second);
-                            if (second.GetType() == typeof(Enemy))
-                            {
-                                _enemiesToRemove.Add(second);
-                            }
+                            _physicsService.HandleTopCollision(first, enemy);
+                            _enemiesToRemove.Add(enemy);
+
                             if (first.GetType() == typeof(Hero))
                             {
                                 first.SetCanJump(true);
@@ -197,7 +205,7 @@ namespace cse210_final_metroidvania
                             // Collision bottom of second actor
                             // Make hero take damage and be pushed in some direction.
                             Console.WriteLine("bottom side collision");
-                            _physicsService.HandleBottomCollision(first, second);
+                            _physicsService.HandleBottomCollision(first, enemy);
                         }
                     }
                 }

--- a/Scripting/MoveActorsAction.cs
+++ b/Scripting/MoveActorsAction.cs
@@ -15,7 +15,7 @@ namespace cse210_final_metroidvania.Scripting
         {
         }
 
-        public override void Execute(Dictionary<string, List<Actor>> cast)
+        public override string Execute(Dictionary<string, List<Actor>> cast)
         {
             foreach (List<Actor> group in cast.Values)
             {
@@ -24,6 +24,8 @@ namespace cse210_final_metroidvania.Scripting
                     MoveActor(actor);
                 }
             }
+
+            return _newRoom;
         }
         
         private void MoveActor(Actor actor)

--- a/Services/CastPrepService.cs
+++ b/Services/CastPrepService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using cse210_final_metroidvania.Casting;
+using cse210_final_metroidvania.Casting.EnvironmentElements;
+
+
+namespace cse210_final_metroidvania
+{
+    public class CastPrepService
+    {
+        public CastPrepService()
+        {
+
+        }
+
+        public Dictionary<string, List<Actor>> PopulateCast(Dictionary<string, Dictionary<string, List<Actor>>> map, string room_name)
+        //  Hero hero)
+        {
+            Dictionary<string, List<Actor>> cast = new Dictionary<string, List<Actor>>();
+
+            Console.WriteLine($"Room Name: {room_name}");
+
+            if (map.ContainsKey(room_name))
+            {
+                foreach (KeyValuePair<string, List<Actor>> cast_type in map[room_name])
+                {
+                    Console.WriteLine($"Cast Type: {cast_type.Key}");
+                    cast[cast_type.Key] = cast_type.Value;
+                }
+            }
+            
+            // cast["heros"].Add(hero);
+            return cast;
+        }
+    }
+}


### PR DESCRIPTION
This is more of a major update for the programmer. Level data is now stored in a dictionary and can be retrieved by passing in the name you gave to the room created. Right now, only the door can change rooms, but there may be other things that trigger that in the future. There are now base parent classes for Enviromental Elements, Enemies, and HUD Elements. This should hopefully make adding things in the future a lot easier.

Changes:
- New Room
- New Door object
- New Brick object
- HUD now displays player speed